### PR TITLE
[TF-976] Newsroom changes language on clicking media gallery

### DIFF
--- a/pages/media/album/[uuid].tsx
+++ b/pages/media/album/[uuid].tsx
@@ -8,7 +8,7 @@ import type { FunctionComponent } from 'react';
 import { importMessages, isTrackingEnabled } from '@/utils';
 import type { BasePageProps } from 'types';
 
-const Gallery = dynamic(() => import('@/modules/Gallery'), { ssr: true });
+const Gallery = dynamic(() => import('@/modules/Gallery'), { ssr: false });
 
 type Props = BasePageProps & GalleryAlbumPageProps;
 


### PR DESCRIPTION
The following is rendered in `Header.tsx`:

```
                                        <Button.Link
                                            href="/media"
                                            localeCode={getLinkLocaleSlug()}
                                            variation="navigation"
                                            className={styles.navigationButton}
                                        >
                                            <FormattedMessage
                                                {...translations.mediaGallery.title}
                                            />
                                        </Button.Link>
```

When SSR is enabled, the generated URL always point to the default locale (so the href is locale-insensitive).

Is there a better fix though?