### PR TITLE
[QRF-33] Fix contact card links layout

### DIFF
--- a/components/ContactCard/ContactCard.module.scss
+++ b/components/ContactCard/ContactCard.module.scss
@@ -66,6 +66,10 @@
 
 .socials {
     display: flex;
+
+    .link:last-child {
+        margin-right: 0;
+    }
 }
 
 .icon {


### PR DESCRIPTION
- Use `tablet-up` instead of `tablet-only` to have the same layout for contact cards in desktop and tablet
- Use `overflow-wrap: break-word;` to make sure links are always visible [according to this](https://www.figma.com/file/j0ty2jW7wHD4bFcOyWn39a/Working-%F0%9F%9A%A7-Bea-Theme?node-id=707%3A4523)
- Use `flex-wrap: wrap;` to ensure links can go to next line if they don't fit on a single line

Once you approve, I will port these changes to Bea