### PR TITLE
[DEV-12946] Feature - Add support for different logo sizes

### DIFF
--- a/hooks/useThemeSettings/constants.ts
+++ b/hooks/useThemeSettings/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_THEME_SETTINGS: ThemeSettingsApiResponse = {
     font: Font.INTER,
     header_background_color: '#ffffff',
     header_link_color: '#4b5563',
+    logo_size: 'medium',
     show_date: true,
     show_subtitle: false,
 };

--- a/hooks/useThemeSettings/useThemeSettings.ts
+++ b/hooks/useThemeSettings/useThemeSettings.ts
@@ -31,6 +31,7 @@ export function useThemeSettings(): ThemeSettings {
         font: settings.font,
         headerBackgroundColor: settings.header_background_color,
         headerLinkColor: settings.header_link_color,
+        logoSize: settings.logo_size,
         showDate: settings.show_date,
         showSubtitle: settings.show_subtitle,
     };

--- a/hooks/useThemeSettings/utils.ts
+++ b/hooks/useThemeSettings/utils.ts
@@ -28,6 +28,7 @@ export function parseQuery(query: Partial<ThemeSettingsQuery>): Partial<ThemeSet
         font: query.font,
         header_background_color: query.header_background_color,
         header_link_color: query.header_link_color,
+        logo_size: query.logo_size,
         show_date,
         show_subtitle,
     };

--- a/modules/Layout/Header/Header.module.scss
+++ b/modules/Layout/Header/Header.module.scss
@@ -3,7 +3,7 @@ $header-height: 88px;
 .container {
     display: flex;
     background: var(--prezly-header-background-color);
-    height: $header-height;
+    min-height: $header-height;
     z-index: 2;
 }
 
@@ -86,6 +86,8 @@ $header-height: 88px;
 
 .newsroom {
     @include link-primary;
+
+    display: flex;
 
     &.withoutLogo {
         color: var(--prezly-header-link-color);

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -6,7 +6,6 @@ import {
     useGetLinkLocaleSlug,
     useNewsroom,
 } from '@prezly/theme-kit-nextjs';
-import UploadcareImage from '@uploadcare/nextjs-loader';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -14,13 +13,13 @@ import type { MouseEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { useDevice, useDisplayedLanguages } from '@/hooks';
+import { useDevice, useDisplayedLanguages, useThemeSettings } from '@/hooks';
 import { IconClose, IconMenu, IconSearch } from '@/icons';
 import { Button, ButtonLink } from '@/ui';
-import { getUploadcareImage } from '@/utils';
 
 import CategoriesDropdown from './CategoriesDropdown';
 import LanguagesDropdown from './LanguagesDropdown';
+import { Logo } from './Logo';
 
 import styles from './Header.module.scss';
 
@@ -32,6 +31,7 @@ interface Props {
 
 function Header({ hasError }: Props) {
     const { newsroom_logo, display_name, public_galleries_number } = useNewsroom();
+    const { logoSize } = useThemeSettings();
     const categories = useCategories();
     const displayedLanguages = useDisplayedLanguages();
     const { name } = useCompanyInformation();
@@ -94,7 +94,6 @@ function Header({ hasError }: Props) {
     }, [isMenuOpen]);
 
     const newsroomName = name || display_name;
-    const newsroomLogo = getUploadcareImage(newsroom_logo);
 
     return (
         <header ref={headerRef} className={styles.container}>
@@ -114,15 +113,7 @@ function Header({ hasError }: Props) {
                         >
                             {newsroomName}
                         </h1>
-                        {newsroomLogo && (
-                            <UploadcareImage
-                                alt={newsroomName}
-                                className={styles.logo}
-                                src={newsroomLogo.cdnUrl}
-                                width={320}
-                                height={56}
-                            />
-                        )}
+                        <Logo image={newsroom_logo} size={logoSize} />
                     </Link>
 
                     <div className={styles.navigationWrapper}>

--- a/modules/Layout/Header/Logo/Logo.module.scss
+++ b/modules/Layout/Header/Logo/Logo.module.scss
@@ -1,0 +1,32 @@
+.logo {
+    width: auto;
+    object-fit: contain;
+
+    &.landscape {
+        &.small {
+            max-width: 5rem;
+        }
+    
+        &.medium {
+            max-width: 10rem;
+        }
+    
+        &.large {
+            max-width: 15rem;
+        }
+    }
+
+    &.portrait {
+        &.small {
+            max-height: 3.5rem;
+        }
+    
+        &.medium {
+            max-height: 4.5rem;
+        }
+    
+        &.large {
+            max-height: 5.5rem;
+        }
+    }
+}

--- a/modules/Layout/Header/Logo/Logo.tsx
+++ b/modules/Layout/Header/Logo/Logo.tsx
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import type { UploadedImage } from '@prezly/uploadcare';
+import UploadcareImage from '@uploadcare/nextjs-loader';
+import classNames from 'classnames';
+
+import { useDevice } from 'hooks';
+import { getUploadcareImage } from 'utils';
+
+import styles from './Logo.module.scss';
+
+enum LogoSize {
+    SMALL = 'small',
+    MEDIUM = 'medium',
+    LARGE = 'large',
+}
+
+interface Props {
+    image: UploadedImage | null;
+    size: string;
+}
+
+const REM = 16;
+
+export function Logo({ image, size: preferredSize }: Props) {
+    const device = useDevice();
+    const uploadcareImage = getUploadcareImage(image);
+
+    if (!uploadcareImage) {
+        return null;
+    }
+
+    const { aspectRatio } = uploadcareImage;
+    const isLandscape = uploadcareImage.aspectRatio > 1;
+
+    let width;
+    let height;
+    let size = isSupportedLogoSize(preferredSize) ? preferredSize : LogoSize.MEDIUM;
+
+    // For mobile we want to override the logo size so it looks good
+    if (device.isMobile) {
+        size = isLandscape ? LogoSize.MEDIUM : LogoSize.SMALL;
+    }
+
+    if (aspectRatio > 1) {
+        // landscape
+        width = getWidth(size);
+        height = width / aspectRatio;
+    } else {
+        // portrait
+        height = getHeight(size);
+        width = height / aspectRatio;
+    }
+
+    return (
+        <UploadcareImage
+            src={uploadcareImage.cdnUrl}
+            alt="" // This is a presentation image, the link has text inside <h1>, no need to have it twice. See [DEV-12311].
+            className={classNames(styles.logo, {
+                [styles.landscape]: isLandscape,
+                [styles.portrait]: !isLandscape,
+                [styles.small]: size === 'small',
+                [styles.medium]: size === 'medium',
+                [styles.large]: size === 'large',
+            })}
+            width={width}
+            height={height}
+        />
+    );
+}
+
+function isSupportedLogoSize(size: string): size is LogoSize {
+    return size === 'small' || size === 'medium' || size === 'large';
+}
+
+function getWidth(size: LogoSize) {
+    switch (size) {
+        case LogoSize.LARGE:
+            return 15 * REM;
+        case LogoSize.MEDIUM:
+            return 10 * REM;
+        default:
+            return 5 * REM;
+    }
+}
+
+function getHeight(size: LogoSize) {
+    switch (size) {
+        case LogoSize.LARGE:
+            return 5.5 * REM;
+        case LogoSize.MEDIUM:
+            return 4.5 * REM;
+        default:
+            return 3.5 * REM;
+    }
+}

--- a/modules/Layout/Header/Logo/index.ts
+++ b/modules/Layout/Header/Logo/index.ts
@@ -1,0 +1,1 @@
+export { Logo } from './Logo';

--- a/types.ts
+++ b/types.ts
@@ -21,6 +21,7 @@ export interface ThemeSettingsApiResponse {
     font: Font;
     header_background_color: string;
     header_link_color: string;
+    logo_size: string;
     show_date: boolean;
     show_subtitle: boolean;
 }
@@ -30,6 +31,7 @@ export interface ThemeSettings {
     font: Font;
     headerBackgroundColor: string;
     headerLinkColor: string;
+    logoSize: string;
     showDate: boolean;
     showSubtitle: boolean;
 }


### PR DESCRIPTION
- added support for various logo sizes - `small`, `medium` and `large`
- added support for previewing the logo size via `logo_size` query parameter
- on mobile, we force `medium` size for landscape logos and `small` size for portrait/square logos